### PR TITLE
Fixed CORS

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -23,3 +23,5 @@ RABBITMQ_PASS = ''
 LOG_LEVEL = 'DEBUG'
 LOGGER_URL = 'http://localhost:3100/loki/api/v1/push'
 CONSOLE_LOG = true
+
+APP_DOMAIN = 'https://brixiacodingchallenge.unibs.it'

--- a/app/config.py
+++ b/app/config.py
@@ -26,6 +26,8 @@ class Settings(BaseSettings):
     LOGGER_URL: str
     CONSOLE_LOG: bool
 
+    APP_DOMAIN: str
+
     model_config = SettingsConfigDict(env_file=".env")
     
     @property

--- a/app/routers/auth.py
+++ b/app/routers/auth.py
@@ -53,7 +53,7 @@ async def login(response: Response, body: UserLoginDTO = Body(), session = Depen
 
     try:
         token: Token = login_controller(body, session)
-        response.set_cookie('byteblitz_token', token['access_token'], httponly=True)
+        response.set_cookie('token', token['access_token'], httponly=True)
         return token
         
     except HTTPException as http_exc:

--- a/app/routers/auth.py
+++ b/app/routers/auth.py
@@ -67,7 +67,37 @@ async def login(response: Response, body: UserLoginDTO = Body(), session = Depen
             status_code=500,
             content={"detail": "An unexpected error occurred", "error": str(e)}
         )
+
+@router.get("/logout", summary="Logout", response_description="User logged out")
+def logout(response: Response) -> JSONResponse:
+    """
+    Logout a user clearing the cookies
     
+    Returns:
+        JSONResponse: response
+    """
+
+    # response.delete_cookie('token', httponly=True)
+    try:
+        response.delete_cookie('token', httponly=True)
+        return JSONResponse(
+            status_code=200,
+            content={"detail": "Logout successful"},
+            headers=response.headers
+        )
+        
+    except HTTPException as http_exc:
+        # Handle known HTTP exceptions raised within the controller
+        return JSONResponse(
+            status_code=http_exc.status_code,
+            content={"detail": http_exc.detail}
+        )
+    except Exception as e:
+        return JSONResponse(
+            status_code=500,
+            content={"detail": "An unexpected error occurred", "error": str(e)}
+        )
+
 # @router.post("/refresh", summary="Refresh token", response_description="Token refreshed", response_model=Token)
 # async def refresh_token(token):
 

--- a/main.py
+++ b/main.py
@@ -4,12 +4,13 @@ from fastapi.middleware.cors import CORSMiddleware
 
 from app.logger import LoggingMiddleware, get_logger
 from app.routers import auth, contest, problem, submission, user, general
+from app.config import settings
 
 app = FastAPI(title="ByteBlitz", description="API for ByteBlitz", version="0.1")
 
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=["*"],
+    allow_origins=[settings.APP_DOMAIN],
     allow_methods=["*"],
     allow_headers=["*"],
     allow_credentials=True


### PR DESCRIPTION
The browser trigger an error when using the field 'withCredentials' set to true if the server set the header 'Access-Control-Allow-Origin' = '*'. Setting the right domain (in the .env) resolve the issue